### PR TITLE
Mark lighter variable as risky

### DIFF
--- a/firestarter.el
+++ b/firestarter.el
@@ -43,7 +43,8 @@
 (defcustom firestarter-lighter " 🔥"
   "Lighter for `firestarter-mode'."
   :type 'string
-  :group 'firestarter)
+  :group 'firestarter
+  :risky t)
 
 (defvar firestarter nil
   "Command to run on file save.


### PR DESCRIPTION
Mode line variables should be risky.  Otherwise Emacs silently ignores any non-trivial mode line construct in them (i.e. `:eval` or `:properties`), as well as any text properties on the string.

See `symbol` in [Mode Line Data](http://www.gnu.org/software/emacs/manual/html_node/elisp/Mode-Line-Data.html#Mode-Line-Data) for details.
