### PR TITLE
Add option to kill the process if already running

### DIFF
--- a/firestarter.el
+++ b/firestarter.el
@@ -66,6 +66,11 @@ t, 'finished: Report after either outcome once the subprocess quit."
                  (const :tag "Finished" finished))
   :group 'firestarter)
 
+(defcustom firestarter-auto-kill nil
+  "Whether the current process should automatically be killed when starting a new."
+  :type 'boolean
+  :group 'firestarted)
+
 (defvar firestarter-type nil
   "Current shell command reporting type.
 See `firestarter-default-type' for valid values.")
@@ -105,25 +110,32 @@ Available format codes are:
   :type 'string
   :group 'firestarter)
 
+(defun firestarter-process-running-p ()
+  "Return non-nil if a process is currently running."
+  (and firestarter-process
+       (not (memq (process-status firestarter-process)
+                  '(exit signal nil)))))
+
 (defun firestarter-command (command &optional type)
   "Execute COMMAND in a shell.
 Optionally, override the reporting type as documented in
 `firestarter-default-type' with TYPE."
-  (if (and firestarter-process
-           (not (memq (process-status firestarter-process)
-                      '(exit signal nil))))
-      (error "Process already running")
-    (setq firestarter-process
-          (start-process "firestarter" nil
-                         shell-file-name shell-command-switch
-                         (firestarter-format command)))
-    (process-put firestarter-process 'output "")
-    (process-put firestarter-process 'type
-                 (or type firestarter-type firestarter-default-type))
-    (process-put firestarter-process 'buffer-name
-                 (buffer-name (current-buffer)))
-    (set-process-filter firestarter-process 'firestarter-filter)
-    (set-process-sentinel firestarter-process 'firestarter-sentinel)))
+  (let ((should-start (or (not (firestarter-process-running-p))
+                          (when firestarter-auto-kill (message "Killing the current process") t)
+                          (y-or-n-p "The current process should be killed to start a new one.  Kill it? "))))
+    (when should-start
+      (firestarter-abort)
+      (setq firestarter-process
+            (start-process "firestarter" nil
+                           shell-file-name shell-command-switch
+                           (firestarter-format command)))
+      (process-put firestarter-process 'output "")
+      (process-put firestarter-process 'type
+                   (or type firestarter-type firestarter-default-type))
+      (process-put firestarter-process 'buffer-name
+                   (buffer-name (current-buffer)))
+      (set-process-filter firestarter-process 'firestarter-filter)
+      (set-process-sentinel firestarter-process 'firestarter-sentinel))))
 
 (defun firestarter-format (string)
   "Apply format codes on STRING.


### PR DESCRIPTION
This adds `firestarter-auto-kill` option. When `non-nil`, firestarter, when asked to start a process, will kill the current process instead of throwing an error.